### PR TITLE
Add CreateConn to allow initiating communication

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -397,7 +397,7 @@ func TestConnClose(t *testing.T) {
 			t.Fatal(errPipe)
 		}
 		// Close l.pConn to inject error.
-		if err := l.(*listener).pConn.Close(); err != nil {
+		if err := l.(*Listener).pConn.Close(); err != nil {
 			t.Error(err)
 		}
 
@@ -421,7 +421,7 @@ func TestConnClose(t *testing.T) {
 			t.Fatal(errPipe)
 		}
 		// Close l.pConn to inject error.
-		if err := l.(*listener).pConn.Close(); err != nil {
+		if err := l.(*Listener).pConn.Close(); err != nil {
 			t.Error(err)
 		}
 


### PR DESCRIPTION
Adds a CreateConn function to allow for the use case of an application
that listens for new UDP connections on a specific port but then also
wants to be able to initiate connections from that same port. As part of
this, the listener type is exported so that created Listeners can be
cast back to udp.Listener from the net.Listener interface.